### PR TITLE
Replace deprecated threading.currentThread with current_thread

### DIFF
--- a/zthreading/tasks.py
+++ b/zthreading/tasks.py
@@ -250,7 +250,7 @@ class Task(EventHandler):
             if self.use_async_loop:
                 wait_for_future(self.async_task, timeout)
             # FIXME: Maybe there is a better approach here. Should raise error?
-            elif self._thread.is_alive() and threading.currentThread() != self._thread:
+            elif self._thread.is_alive() and threading.current_thread() != self._thread:
                 self._thread.join(timeout)
 
         if raise_last_exception and self.error is not None:


### PR DESCRIPTION
`threading.currentThread` was deprecated in Python 3.10 (October 2021) and will be removed in Python 3.12 (October 2023).

Replace with `threading.current_thread`, added in Python 2.6 (October 2008).

* https://docs.python.org/3.12/whatsnew/3.10.html#deprecated
* https://github.com/python/cpython/pull/25174